### PR TITLE
Update the version of cmv-server to v1.0.0, update the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - *Fixed (for any bug fixes)*  
 - *Security (in case of vulnerabilities)*
 
-## [1.0.0] - 2023-01-18
+## [1.0.0] - 2023-01-24
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7545331.svg)](https://doi.org/10.5281/zenodo.7545331)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added latest version redirects for monolingual CDC profiles ([#63](https://github.com/cessda/cessda.cmv.server/issues/63))
 - Enabled CORS for the Swagger documentation and the public API ([#67](https://github.com/cessda/cessda.cmv.server/issues/67))
 - Validate the documents against the XML schema when validating in the user interface ([#68](https://github.com/cessda/cessda.cmv.server/issues/68))
+- Transform the metadata profiles as part of the build process ([#DOCS-21](https://github.com/cessda/cessda.cmv.documentation/issues/21))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.0] - 2023-01-18
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7545331.svg)](https://doi.org/10.5281/zenodo.7545331)
+
 ### Added
 
 - Added latest version redirects for monolingual CDC profiles ([#63](https://github.com/cessda/cessda.cmv.server/issues/63))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - *Fixed (for any bug fixes)*  
 - *Security (in case of vulnerabilities)*
 
+## [1.0.0]
+
+### Added
+
+- Added latest version redirects for monolingual CDC profiles ([#63](https://github.com/cessda/cessda.cmv.server/issues/63))
+- Enabled CORS for the Swagger documentation and the public API ([#67](https://github.com/cessda/cessda.cmv.server/issues/67))
+- Validate the documents against the XML schema when validating in the user interface ([#68](https://github.com/cessda/cessda.cmv.server/issues/68))
+
+### Changed
+
+- Update OpenJDK to 17 ([#64](https://github.com/cessda/cessda.cmv.server/issues/64))
+- Replace the JIRA feedback form with the EOSC helpdesk feedback form ([#79](https://github.com/cessda/cessda.cmv.server/issues/79))
+
+### Fixed
+
+- Fixed EQB v0.1.1 profile redirect ([#66](https://github.com/cessda/cessda.cmv.server/issues/66))
+
 ## [0.4.2] - 2021-09-13
 
 ### Added
@@ -82,6 +99,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show notification if DDI document recognition fails ([#19](https://github.com/cessda/cessda.cmv.server/issues/19))
 - Change endpoints urls to be consistent with other CESSDA products ([#18](https://github.com/cessda/cessda.cmv.server/issues/18))
 
+[1.0.0]: https://github.com/cessda/cessda.cmv.server/releases/tag/v1.0.0
+[0.4.2]: https://github.com/cessda/cessda.cmv.server/releases/tag/v0.4.2
+[0.4.1]: https://github.com/cessda/cessda.cmv.server/releases/tag/v0.4.1
 [0.4.0]: https://github.com/cessda/cessda.cmv.server/releases/tag/v0.4.0
 [0.3.1]: https://github.com/cessda/cessda.cmv.server/releases/tag/v0.3.1
 [0.3.0]: https://github.com/cessda/cessda.cmv.server/releases/tag/v0.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>eu.cessda.cmv</groupId>
 			<artifactId>cmv-core</artifactId>
-			<version>0.5.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>eu.cessda.cmv</groupId>
 			<artifactId>cmv-documentation</artifactId>
-			<version>0.5.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>eu.cessda.cmv</groupId>


### PR DESCRIPTION
This PR updates the version number to v1.0.0 and updates the changelog with the changes between the previous version. It also updates the dependencies in the POM.

This is for <https://github.com/cessda/cessda.cmv/issues/142>.