### PR TITLE
Transform the metadata profiles as part of the build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
 				<version>1.0.2</version>
 				<executions>
 					<execution>
+						<phase>generate-resources</phase>
 						<goals>
 							<goal>transform</goal>
 						</goals>
@@ -338,6 +339,7 @@
 					<transformationSets>
 						<transformationSet>
 							<dir>src/main/resources/static/profiles</dir>
+							<excludes>xslt/1.0/stylesheet.xsl</excludes>
 							<stylesheet>src/main/resources/static/profiles/xslt/1.0/stylesheet.xsl</stylesheet>
 							<fileMappers>
 								<fileMapper

--- a/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
+++ b/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
@@ -83,13 +83,24 @@ public class DocumentationConfiguration implements WebMvcConfigurer
 		registry.addRedirectViewController( "/documentation/", "/documentation" );
 
 		// CDC profile redirects
-		registry.addRedirectViewController( "/profiles/cdc/{ddi}/latest/profile.xml", "/profiles/cdc/{ddi}/1.0.4/profile.xml" );
-		registry.addRedirectViewController( "/profiles/cdc/{ddi}/latest/profile-mono.xml", "/profiles/cdc/{ddi}/1.0.4/profile-mono.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-1.2.2/latest/profile.xml", "/profiles/cdc/ddi-1.2.2/1.0.4/profile.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-1.2.2/latest/profile.html", "/profiles/cdc/ddi-1.2.2/1.0.4/profile.html" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-1.2.2/latest/profile-mono.xml", "/profiles/cdc/ddi-1.2.2/1.0.4/profile-mono.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-1.2.2/latest/profile-mono.html", "/profiles/cdc/ddi-1.2.2/1.0.4/profile-mono.html" );
+
+		registry.addRedirectViewController( "/profiles/cdc/ddi-2.5/latest/profile.xml", "/profiles/cdc/ddi-2.5/1.0.4/profile.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-2.5/latest/profile.html", "/profiles/cdc/ddi-2.5/1.0.4/profile.html" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-2.5/latest/profile-mono.xml", "/profiles/cdc/ddi-2.5/1.0.4/profile-mono.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-2.5/latest/profile-mono.html", "/profiles/cdc/ddi-2.5/1.0.4/profile-mono.html" );
+
 		registry.addRedirectViewController( "/profiles/cdc/ddi-3.2/latest/profile.xml", "/profiles/cdc/ddi-3.2/0.1.1/profile.xml" );
+		registry.addRedirectViewController( "/profiles/cdc/ddi-3.2/latest/profile.html", "/profiles/cdc/ddi-3.2/0.1.1/profile.html" );
 
 		// EQB profile redirects
 		registry.addRedirectViewController( "/profiles/eqb/ddi-2.5/latest/profile.xml", "/profiles/eqb/ddi-2.5/0.1.0/profile.xml" );
+		registry.addRedirectViewController( "/profiles/eqb/ddi-2.5/latest/profile.html", "/profiles/eqb/ddi-2.5/0.1.0/profile.html" );
 		registry.addRedirectViewController( "/profiles/eqb/ddi-3.2/latest/profile.xml", "/profiles/eqb/ddi-3.2/0.1.1/profile.xml" );
+		registry.addRedirectViewController( "/profiles/eqb/ddi-3.2/latest/profile.html", "/profiles/eqb/ddi-3.2/0.1.1/profile.html" );
 	}
 
 	@Override


### PR DESCRIPTION
This transforms the XML into HTML as part of the build process, and adds the appropiate redirects to DocumentationConfiguration.

This is part of https://github.com/cessda/cessda.cmv.documentation/issues/21.