### PR TITLE
Migrate away from org.gesis.commons.resource.Resource

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yaml, *.yml}]
+[{*.yaml,*.yml}]
 indent_size = 2
 indent_style = space
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
 			<artifactId>jackson-module-jaxb-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-validator</groupId>
-			<artifactId>commons-validator</artifactId>
-			<version>1.9.0</version>
-		</dependency>
-		<dependency>
 			<groupId>org.zalando</groupId>
 			<artifactId>problem-spring-web</artifactId>
 			<version>0.27.0</version>

--- a/src/main/java/eu/cessda/cmv/server/Server.java
+++ b/src/main/java/eu/cessda/cmv/server/Server.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import eu.cessda.cmv.core.CessdaMetadataValidatorFactory;
 import eu.cessda.cmv.core.NotDocumentException;
 import eu.cessda.cmv.core.Profile;
-import org.gesis.commons.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,22 +37,16 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.UrlResource;
-import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 import org.zalando.problem.jackson.ProblemModule;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-
-import static org.gesis.commons.resource.Resource.newResource;
 
 @SpringBootApplication
 public class Server extends SpringBootServletInitializer
@@ -134,7 +127,7 @@ public class Server extends SpringBootServletInitializer
 	}
 
 	@Bean
-	public List<Resource.V10> demoDocuments() throws IOException
+	public List<org.springframework.core.io.Resource> demoDocuments() throws IOException
 	{
 		log.info( "Discovering built-in documents" );
 		var resources = applicationContext.getResources("classpath*:**/demo-documents/ddi-v25/*.xml");
@@ -148,39 +141,6 @@ public class Server extends SpringBootServletInitializer
 			log.debug( "\"{}\" excluded", excluded );
 		}
 
-		var resourcesWithFileNames = new ArrayList<Resource.V10>();
-
-		for ( var resource : includedResourcesSet )
-		{
-			log.debug( "Discovering document at \"{}\"", resource );
-			try
-			{
-				URI uri;
-				if ( resource instanceof UrlResource urlResource )
-				{
-					// Clean URL paths, needed on Windows as URIs don't accept '\'
-					var urlString = urlResource.getURL().toString();
-					var cleanedURL = StringUtils.cleanPath( urlString );
-					uri = new URI( cleanedURL );
-				}
-				else
-				{
-					uri = resource.getURI();
-				}
-
-				var fileName = resource.getFilename();
-
-				// This shouldn't be null if a URI is set
-				assert fileName != null;
-
-				resourcesWithFileNames.add( newResource( uri, fileName ) );
-			}
-			catch ( IOException | URISyntaxException e )
-			{
-				log.error( "Resource \"{}\" cannot be converted into a URI", resource, e );
-			}
-		}
-
-		return resourcesWithFileNames;
+		return new ArrayList<>( includedResourcesSet );
 	}
 }

--- a/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
@@ -9,9 +9,9 @@ package eu.cessda.cmv.server.ui;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,8 @@ package eu.cessda.cmv.server.ui;
  */
 
 import org.springframework.core.io.ByteArrayResource;
+
+import java.util.Objects;
 
 public class FilenameResource extends ByteArrayResource
 {
@@ -42,5 +44,20 @@ public class FilenameResource extends ByteArrayResource
 	public String getDescription()
 	{
 		return "File name resource [" + this.fileName + "]";
+	}
+
+	@Override
+	public boolean equals( Object o )
+	{
+		if ( this == o ) return true;
+		if ( !( o instanceof FilenameResource that ) ) return false;
+		if ( !super.equals( o ) ) return false;
+		return Objects.equals( fileName, that.fileName );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( super.hashCode(), fileName );
 	}
 }

--- a/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
@@ -1,0 +1,46 @@
+package eu.cessda.cmv.server.ui;
+
+/*-
+ * #%L
+ * CESSDA Metadata Validator
+ * %%
+ * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.springframework.core.io.ByteArrayResource;
+
+public class FilenameResource extends ByteArrayResource
+{
+	private final String fileName;
+
+	public FilenameResource( byte[] byteArray, String fileName )
+	{
+		super( byteArray );
+		this.fileName = fileName;
+	}
+
+	@Override
+	public String getFilename()
+	{
+		return fileName;
+	}
+
+	@Override
+	public String getDescription()
+	{
+		return "File name resource [" + this.fileName + "]";
+	}
+}

--- a/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
+++ b/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
@@ -7,6 +7,7 @@ pasteUrl=Paste url
 
 # Upload control
 upload.caption=Files
+upload.failedCaption=Upload Failed
 upload.fileTooBigPattern=File is too big (max = {0}): {2} ({1})
 upload.multipleFiles=Upload Files
 upload.singleFile=Upload File

--- a/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
+++ b/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
@@ -7,10 +7,10 @@ pasteUrl=Paste url
 
 # Upload control
 upload.caption=Files
-upload.failedCaption=Upload Failed
+upload.failedCaption=Upload failed
 upload.fileTooBigPattern=File is too big (max = {0}): {2} ({1})
-upload.multipleFiles=Upload Files
-upload.singleFile=Upload File
+upload.multipleFiles=Upload files
+upload.singleFile=Upload file
 
 # Provisioning options
 BY_PREDEFINED=Predefined items

--- a/src/main/webapp/VAADIN/themes/cmv/layouts/copyrightText.html
+++ b/src/main/webapp/VAADIN/themes/cmv/layouts/copyrightText.html
@@ -55,7 +55,7 @@
 <p>
 Creative Commons Licensing Types: <a href="https://creativecommons.org/share-your-work/licensing-types-examples/" target="_blank" rel="noopener noreferrer">https://creativecommons.org/share-your-work/licensing-types-examples/</a></p>
 <p>
-License Selector by Institute of Formal and Applied Linguistics (ÚFAL), Faculty of Mathematics and Physics, Charles University in Prague <a href="https://ufal.github.io/public-license-selector/" traget="_blank">https://ufal.github.io/public-license-selector/</a> (Note: the tool focuses on software and data but can also be used for other works)
+License Selector by Institute of Formal and Applied Linguistics (ÚFAL), Faculty of Mathematics and Physics, Charles University in Prague <a href="https://ufal.github.io/public-license-selector/" target="_blank">https://ufal.github.io/public-license-selector/</a> (Note: the tool focuses on software and data but can also be used for other works)
 </p>
 		</div>
 </section>

--- a/src/main/webapp/VAADIN/themes/cmv/layouts/seperator.html
+++ b/src/main/webapp/VAADIN/themes/cmv/layouts/seperator.html
@@ -1,2 +1,2 @@
-<div class="vertical-line" style=" margin-left:30px; width: 2px;  background-color: rgba(172,166,144,0.20); height: 100%;  float: left;" />
+<div class="vertical-line" style=" margin-left:30px; width: 2px;  background-color: rgba(172,166,144,0.20); height: 100%;  float: left;" ></div>
 

--- a/src/test/java/eu/cessda/cmv/server/ValidationControllerV0Test.java
+++ b/src/test/java/eu/cessda/cmv/server/ValidationControllerV0Test.java
@@ -272,7 +272,7 @@ class ValidationControllerV0Test
 		var requestJSON = this.getClass().getResource( "/invalidRequest.json" );
 		var validationRequest = objectMapper.readValue( requestJSON, ValidationRequest.class );
 
-		validationRequest.setConstraints( Collections.singleton( validationRequest.getConstraints().get( 0 ) ) );
+		validationRequest.setConstraints( Collections.singleton( validationRequest.getConstraints().getFirst() ) );
 
 		MediaType mediaType = MediaType.APPLICATION_JSON;
 		String responseBody = mockMvc.perform(post(uriBuilder.toEncodedString() )


### PR DESCRIPTION
`org.gesis.commons.resource.Resource` has type safety issues with the constructor as well as usability issues . This PR replaces uses of `org.gesis.commons.resource.Resource` with `org.springframework.core.io.Resource`.