### PR TITLE
Fix the profile name being null if the profile document is missing a name

### DIFF
--- a/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
+++ b/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/SchemaViolation.java
+++ b/src/main/java/eu/cessda/cmv/server/SchemaViolation.java
@@ -4,7 +4,7 @@ package eu.cessda.cmv.server;
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/Server.java
+++ b/src/main/java/eu/cessda/cmv/server/Server.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import eu.cessda.cmv.core.CessdaMetadataValidatorFactory;
 import eu.cessda.cmv.core.NotDocumentException;
 import eu.cessda.cmv.core.Profile;
+import eu.cessda.cmv.server.ui.UIProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,19 +91,19 @@ public class Server extends SpringBootServletInitializer
 	}
 
 	@Bean
-	public List<Profile> demoProfiles( CessdaMetadataValidatorFactory factory ) throws IOException
+	public List<UIProfile> demoProfiles( CessdaMetadataValidatorFactory factory ) throws IOException
 	{
 		log.info( "Loading built-in profiles" );
 
 		var resources = applicationContext.getResources( "classpath*:**/profiles/**/*.xml" );
-		var profiles = new ArrayList<Profile>(resources.length);
+		var profiles = new ArrayList<UIProfile>(resources.length);
 		for ( var resource : resources )
 		{
 			log.debug( "Loading profile from \"{}\"", resource );
 			try( var inputStream = resource.getInputStream() )
 			{
 				var profile = factory.newProfile( inputStream );
-				profiles.add( profile );
+				profiles.add( new UIProfile( profile, resource ) );
 			}
 			catch ( NotDocumentException | IOException e )
 			{

--- a/src/main/java/eu/cessda/cmv/server/Server.java
+++ b/src/main/java/eu/cessda/cmv/server/Server.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ValidationReport.java
+++ b/src/main/java/eu/cessda/cmv/server/ValidationReport.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/ValidatorEngine.java
+++ b/src/main/java/eu/cessda/cmv/server/ValidatorEngine.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/api/ExceptionHandlerAdvice.java
+++ b/src/main/java/eu/cessda/cmv/server/api/ExceptionHandlerAdvice.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/api/ResourceNotFoundException.java
+++ b/src/main/java/eu/cessda/cmv/server/api/ResourceNotFoundException.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/api/SwaggerConfiguration.java
+++ b/src/main/java/eu/cessda/cmv/server/api/SwaggerConfiguration.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/api/ValidationControllerV0.java
+++ b/src/main/java/eu/cessda/cmv/server/api/ValidationControllerV0.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ui/CSVException.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/CSVException.java
@@ -4,7 +4,7 @@ package eu.cessda.cmv.server.ui;
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/ui/ErrorHandler.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ErrorHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/ui/ErrorWindow.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ErrorWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
@@ -4,14 +4,14 @@ package eu.cessda.cmv.server.ui;
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ui/ResourceSelectionComponent.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ResourceSelectionComponent.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ui/ResourceSelectionComponent.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ResourceSelectionComponent.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,10 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.ResourceBundle;
+import java.util.*;
 
 import static com.vaadin.shared.ui.grid.HeightMode.ROW;
 import static com.vaadin.ui.Grid.SelectionMode.NONE;
@@ -53,7 +50,7 @@ public class ResourceSelectionComponent<T> extends CustomComponent
 	@Serial
 	private static final long serialVersionUID = -808880272310582714L;
 
-	private final ArrayList<T> selectedResources = new ArrayList<>(1);
+	private final LinkedHashSet<T> selectedResources = new LinkedHashSet<>(1);
 	private final NativeSelect<T> predefinedSelect;
 	private final TextField textField;
 	private final Button clearButton;
@@ -86,7 +83,7 @@ public class ResourceSelectionComponent<T> extends CustomComponent
 	public ResourceSelectionComponent(
 		SelectionMode selectionMode,
 		ProvisioningOptions selectedProvisioningOption,
-		List<T> predefinedResources,
+		Collection<T> predefinedResources,
 		ItemCaptionGenerator<T> stringMapper,
 		SerializableFunction<Resource, Optional<T>> resourceValidator)
 	{
@@ -103,7 +100,7 @@ public class ResourceSelectionComponent<T> extends CustomComponent
 	public ResourceSelectionComponent(
             SelectionMode selectionMode,
             ProvisioningOptions selectedProvisioningOption,
-            List<T> predefinedResources,
+            Collection<T> predefinedResources,
 			ItemCaptionGenerator<T> stringMapper,
 			SerializableFunction<T, Label> labelMapper,
 			SerializableFunction<Resource, Optional<T>> resourceValidator)
@@ -221,8 +218,14 @@ public class ResourceSelectionComponent<T> extends CustomComponent
 		{
 			selectedResources.clear();
 		}
-		selectedResources.add( resource );
-		refreshComponents();
+		if (selectedResources.add( resource ))
+		{
+			refreshComponents();
+		}
+		else
+		{
+			Notification.show(bundle.getString("documentAlreadySelected"));
+		}
 	}
 
 	/**

--- a/src/main/java/eu/cessda/cmv/server/ui/ResultsComponent.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ResultsComponent.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ui/UIProfile.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/UIProfile.java
@@ -1,0 +1,33 @@
+package eu.cessda.cmv.server.ui;
+
+/*-
+ * #%L
+ * CESSDA Metadata Validator
+ * %%
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import eu.cessda.cmv.core.Profile;
+import org.springframework.core.io.Resource;
+
+/**
+ * Container to hold the parsed profile and its source resource.
+ *
+ * @param profile the profile.
+ * @param resource the resource.
+ */
+public record UIProfile(Profile profile, Resource resource) {
+}

--- a/src/main/java/eu/cessda/cmv/server/ui/UiView.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/UiView.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
@@ -111,7 +111,7 @@ public class ValidationView extends VerticalLayout implements View
                 SINGLE,
                 BY_PREDEFINED,
                 demoProfiles,
-				profile -> profile.getProfileName() + ": " + profile.getProfileVersion(),
+				ValidationView::getProfileDescription,
                 this::parseProfile
 		);
 		this.profileSelectionComponent.setCaption( bundle.getString( "configuration.profileSelectionCaption" ) );
@@ -139,6 +139,23 @@ public class ValidationView extends VerticalLayout implements View
 		addComponent( configurationPanel );
 		addComponent( validateLayout );
 		addComponent( reportPanel );
+	}
+
+	/**
+	 * Get a description of a profile.
+	 */
+	private static String getProfileDescription(Profile profile) {
+		// Extract the profile's name and version if present
+		if (profile.getProfileName() != null) {
+			if (profile.getProfileVersion() != null) {
+				return profile.getProfileName() + ": " + profile.getProfileVersion();
+			} else {
+				return profile.getProfileName();
+			}
+		} else {
+			// TODO: replace with filename
+			return "UNNAMED PROFILE";
+		}
 	}
 
 	private static Label labelFromResource( Resource resource )

--- a/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
@@ -223,7 +223,7 @@ public class ValidationView extends VerticalLayout implements View
 		{
 			// Profile couldn't be parsed - warn the user
 			log.warn( "Parsing profile \"{}\" failed", resource, e );
-			Notification.show( this.bundle.getString("validate.profileError"), e.getMessage(), Notification.Type.WARNING_MESSAGE );
+			Notification.show( this.bundle.getString("validate.profileError"), e.getMessage(), Notification.Type.ERROR_MESSAGE );
 			return Optional.empty();
 		}
 	}

--- a/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
+++ b/src/main/resources/eu/cessda/cmv/server/ui/ResourceSelectionComponent.properties
@@ -2,6 +2,7 @@
 clear=Clear
 clearAll=Clear all
 comboBox.select=Select resource
+documentAlreadySelected=Document already selected
 invalidURL=Input is not a valid url
 pasteUrl=Paste url
 

--- a/src/test/java/eu/cessda/cmv/server/ExceptionHandlerAdviceTest.java
+++ b/src/test/java/eu/cessda/cmv/server/ExceptionHandlerAdviceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/cessda/cmv/server/SwaggerConfigurationTest.java
+++ b/src/test/java/eu/cessda/cmv/server/SwaggerConfigurationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/cessda/cmv/server/ValidationControllerV0Test.java
+++ b/src/test/java/eu/cessda/cmv/server/ValidationControllerV0Test.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/eu/cessda/cmv/server/ValidationEngineTest.java
+++ b/src/test/java/eu/cessda/cmv/server/ValidationEngineTest.java
@@ -2,14 +2,14 @@
  * #%L
  * CESSDA Metadata Validator
  * %%
- * Copyright (C) 2020 - 2024 CESSDA ERIC
+ * Copyright (C) 2020 - 2025 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
If the profile doesn't specify a name, the profile name should be derived from the file name.