### PR TITLE
Add a cancellation button to cancel long-running validations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@
 		    <version>2.14.1</version>
 		</dependency>
 
+		<!-- Async Processing -->
+		<dependency>
+			<groupId>io.reactivex.rxjava3</groupId>
+			<artifactId>rxjava</artifactId>
+			<version>3.1.10</version>
+		</dependency>
+
 		<!-- JSON API Dependencies -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,8 @@
 
 		<!-- Async Processing -->
 		<dependency>
-			<groupId>io.reactivex.rxjava3</groupId>
-			<artifactId>rxjava</artifactId>
-			<version>3.1.10</version>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
 		</dependency>
 
 		<!-- JSON API Dependencies -->

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}

--- a/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/FilenameResource.java
@@ -9,9 +9,9 @@ package eu.cessda.cmv.server.ui;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package eu.cessda.cmv.server.ui;
  */
 
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.lang.NonNull;
 
 import java.util.Objects;
 
@@ -41,6 +42,7 @@ public class FilenameResource extends ByteArrayResource
 	}
 
 	@Override
+	@NonNull
 	public String getDescription()
 	{
 		return "File name resource [" + this.fileName + "]";

--- a/src/main/java/eu/cessda/cmv/server/ui/ResultsComponent.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ResultsComponent.java
@@ -303,7 +303,7 @@ public class ResultsComponent extends CustomComponent
 	private static <T> void generateCSV( Iterable<T> values, Function<T, String[]> stringMapper, OutputStream outputStream )
 	{
 		// Add headers to the CSV
-		var csvFormat = CSVFormat.RFC4180.builder().setHeader( "lineNumber", "columnNumber", "message" ).build();
+		var csvFormat = CSVFormat.RFC4180.builder().setHeader( "lineNumber", "columnNumber", "message" ).get();
 
 		try
 		{

--- a/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/ValidationView.java
@@ -364,4 +364,12 @@ public class ValidationView extends VerticalLayout implements View
 		validateButton.setEnabled( true );
 		cancelButton.setVisible( false );
 	}
+
+	@Override
+	public void detach()
+	{
+		// Terminate any running validations
+		subscription.dispose();
+		super.detach();
+	}
 }


### PR DESCRIPTION
This PR adds a cancel button to allow users to stop further processing of validations. This is useful when a user has selected a wrong document and doesn't want to wait for the validations to complete before entering new information.

This closes #170.