### PR TITLE
Add OAI-PMH ListRecords response support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ FROM eclipse-temurin:21
 LABEL maintainer='CESSDA-ERIC "support@cessda.eu"'
 
 # Copy JAR artifacts
-COPY ./target/cmv-server.jar /opt/cmv-server/cmv-server.jar
+WORKDIR /opt/cessda/cmv-server
+COPY ./target/cmv-server.jar /opt/cessda/cmv-server/cmv-server.jar
 
 # Entrypoint - Start Admin
-ENTRYPOINT ["java", "-jar", "/opt/cmv-server/cmv-server.jar"]
+ENTRYPOINT ["java", "-jar", "cmv-server.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
 			steps {
 				sh "gcloud auth configure-docker ${ARTIFACT_REGISTRY_HOST}"
 				sh "docker push ${IMAGE_TAG}"
-				sh "gcloud container images add-tag ${IMAGE_TAG} ${DOCKER_ARTIFACT_REGISTRY}/${productName}-${componentName}:${env.BRANCH_NAME}-latest"
+				sh "gcloud artifacts docker tags add ${IMAGE_TAG} ${DOCKER_ARTIFACT_REGISTRY}/${productName}-${componentName}:${env.BRANCH_NAME}-latest"
 			}
 			when { branch 'main' }
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>eu.cessda.cmv</groupId>
 			<artifactId>cmv-core</artifactId>
-			<version>4.0.0</version>
+			<version>4.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- Spring Boot -->

--- a/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
+++ b/src/main/java/eu/cessda/cmv/server/DocumentationConfiguration.java
@@ -41,6 +41,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Configures the web application to serve the documentation and metadata profiles.
+ */
 @Configuration
 public class DocumentationConfiguration implements WebMvcConfigurer
 {

--- a/src/main/java/eu/cessda/cmv/server/Server.java
+++ b/src/main/java/eu/cessda/cmv/server/Server.java
@@ -52,7 +52,10 @@ import java.util.List;
 @SpringBootApplication
 public class Server extends SpringBootServletInitializer
 {
-	private static final Logger log = LoggerFactory.getLogger( Server.class );
+    private static final Logger log = LoggerFactory.getLogger( Server.class );
+
+	// Logging constants
+	public static final String NOT_LIST_RECORDS_RESPONSE = "\"{}\" is not a ListRecords response";
 
 	private final ApplicationContext applicationContext;
 

--- a/src/main/java/eu/cessda/cmv/server/ui/CSVException.java
+++ b/src/main/java/eu/cessda/cmv/server/ui/CSVException.java
@@ -9,9 +9,9 @@ package eu.cessda.cmv.server.ui;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,13 +22,16 @@ package eu.cessda.cmv.server.ui;
 
 import java.io.Serial;
 
+/**
+ * Thrown when an error occurs generating a CSV export.
+ */
 public class CSVException extends RuntimeException
 {
 	@Serial
 	private static final long serialVersionUID = -1872344688892683911L;
 
 	/**
-	 * Constructs a new runtime exception with the specified cause and a
+	 * Constructs a new CSV exception with the specified cause and a
 	 * detail message of {@code (cause==null ? null : cause.toString())}
 	 * (which typically contains the class and detail message of {@code cause}).
 	 *

--- a/src/test/java/eu/cessda/cmv/server/ValidationEngineTest.java
+++ b/src/test/java/eu/cessda/cmv/server/ValidationEngineTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ package eu.cessda.cmv.server;
 import eu.cessda.cmv.core.CessdaMetadataValidatorFactory;
 import eu.cessda.cmv.core.NotDocumentException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.UrlResource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -48,17 +49,17 @@ class ValidationEngineTest
 
 		// Validate
 		var profile = validatorFactory.newProfile( profileResource );
-		try (var documentStream = document.openStream())
-		{
-			var report = validatorEngine.validate(
-					documentStream,
-					profile,
-					BASIC
-			);
+		var documentResource = new UrlResource( document );
+		var report = validatorEngine.validate(
+				documentResource,
+				profile,
+				BASIC
+		);
 
-			// Schema and CMV violations should be found
-			assertThat( report.schemaViolations() ).isNotEmpty();
-			assertThat( report.constraintViolations() ).isNotEmpty();
-		}
+		// Schema and CMV violations should be found
+		assertThat( report ).containsKey( documentResource );
+		var validationReport = report.get( documentResource );
+		assertThat( validationReport.schemaViolations() ).isNotEmpty();
+		assertThat( validationReport.constraintViolations() ).isNotEmpty();
 	}
 }


### PR DESCRIPTION
The server will attempt to split the ListRecords response into multiple documents when validating. The URI of the split documents is `filename#oai-document-id`.

This commit also fixes a bug in `ValidationView.recognizeDdiDocument()` where an `InputStreamResource` would be fully consumed before testing to see if a valid document had been supplied.

This commit updates `cmv-core` to version 4.1.0-SNAPSHOT.

This closes #261